### PR TITLE
merge corrections for JSON-LD & some modifications

### DIFF
--- a/layout/elements/head/jsonld.pug
+++ b/layout/elements/head/jsonld.pug
@@ -17,6 +17,12 @@ if(is_home())
       "copyrightHolder": {
         "@type": "Person",
         "name": !{config.author ? `"${config.author}"` : 'null'}
+      },
+      "mainEntity": {
+        "@type": "ItemList",
+        "itemListElement": [
+          !{ postList && postList.jsonld.length && JSON.stringify(postList.jsonld) }
+        ]
       }
     }
 
@@ -64,7 +70,7 @@ if(is_archive() || is_category() || is_tag())
     {
       "@context": "http://schema.org",
       "@type": "CollectionPage",
-      "name": !{title ? `"${title}"` : 'null'}
+      "name": !{title ? `"${title}"` : 'null'},
       "headline": !{title ? `"${title}"` : 'null'},
       "mainEntity": {
         "@type": "ItemList",

--- a/layout/elements/head/jsonld.pug
+++ b/layout/elements/head/jsonld.pug
@@ -1,18 +1,3 @@
--
-  const full_url = url => {
-    if (!url) return;
-    const {origin, protocol} = new URL(config.url);
-
-    if(/^(https?|file|ftps?|mailto|javascript|data:image\/[^;]{2,9};):/i.test(url)) {
-      return url;
-    }
-    if(url.substring(0,2) == '//') {
-      url = url_for(url);
-      return protocol + url;
-    }
-
-    return origin + url;
-  }
 if(is_home())
   script(type="application/ld+json").
     {
@@ -34,30 +19,14 @@ if(is_home())
         "name": !{config.author ? `"${config.author}"` : 'null'}
       }
     }
+
 if(is_post())
   -
     let keyword = page.tags && page.tags.reduce((str, entry) => {
       return str += entry.name + ',';
     }, ``).replace(/,+\s*$/, '');
   -
-    let representImg = ((seoImage) => {
-      let obj = {};
-      const defaults = {
-        url: null,
-        width: null,
-        height: null,
-      };
-
-      if (!seoImage && !hero.hasHero) return null;
-
-      if(!seoImage) {
-        obj = typeof hero === 'string' ? Object.assign({}, defaults, {url: hero}) : Object.assign({}, defaults, hero);
-      }else {
-        obj = typeof seoImage === 'string' ? Object.assign({}, defaults, {url: seoImage}) : Object.assign({}, defaults, seoImage);
-      }
-
-      return obj;
-    })(page.seo && page.seo.image);
+    let representImg = get_represent_image(page.seo && page.seo.image, hero);
 
   script(type="application/ld+json").
     {

--- a/layout/elements/head/jsonld.pug
+++ b/layout/elements/head/jsonld.pug
@@ -63,7 +63,7 @@ if(is_post())
       "url": !{page.permalink ? `"${page.permalink}"` : 'null'},
       "dateCreated": !{page.date ? `"${date(page.date, null)}"` : 'null'},
       "datePublished": !{page.date ? `"${date(page.date, null)}"` : 'null'},
-      "articleBody": !{meta_description ? `"${meta_description.replace(/\n/, ' ')}"` : 'null'}
+      "articleBody": !{meta_description ? `${JSON.stringify(meta_description.replace(/\n/, ' '))}` : 'null'}
     }
 if(is_archive() || is_category() || is_tag())
   script(type="application/ld+json").

--- a/layout/partials/layout.pug
+++ b/layout/partials/layout.pug
@@ -3,6 +3,8 @@
 -
   const postList = page.posts && page.posts.reduce(function(result, post){
     let excerpt = post.excerpt.replace(/\>\</g, '>\n<') || post.content.substr(0, 1000).replace(/\>\</g, '>\n<');
+    let hero = get_hero(post, theme);
+    let representImg = get_represent_image(post.seo && post.seo.image, hero);
     result.jsonld.push({
       "@type": "BlogPosting",
       "headline": post.title || null,
@@ -21,7 +23,13 @@
       },
       "url": post.permalink || null,
       "dateCreated":  date(post.date, null) || null,
-      "datePublished": date(post.date, null) || null
+      "datePublished": date(post.date, null) || null,
+      "image": representImg && representImg.url ? {
+        "@type": "imageObject",
+        "url": representImg && representImg.url ? `${full_url(representImg.url)}` : null,
+        "width": representImg && representImg.width ? `${representImg.width}` : null,
+        "height": representImg && representImg.height ? `${representImg.height}` : null
+      } : null
     });
     result.list.push({
       title: post.title,

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -142,3 +142,48 @@ hexo.extend.helper.register('scss_post', (scss) => {
 
   return result;
 });
+
+/**
+ * @descript return full url from relative/absolute URL
+ * @param {String} url
+ * @return {String}
+ */
+hexo.extend.helper.register('full_url', (url) => {
+  if (!url) return;
+  const {origin, protocol} = new URL(hexo.config.url);
+
+  if(/^(https?|file|ftps?|mailto|javascript|data:image\/[^;]{2,9};):/i.test(url)) {
+    return url;
+  }
+  if(url.substring(0,2) == '//') {
+    url = hexo.extend.helper.store['url_for'].call(hexo, url);
+    return protocol + url;
+  }
+
+  return origin + url;
+})
+
+/**
+ * @descript return info of representive image
+ * @param {Object} seoImage seo data for the post
+ * @param {Object} hero hero data for the post
+ * @return {Object}
+ */
+hexo.extend.helper.register('get_represent_image', (seoImage, hero) => {
+  let obj = {};
+  const defaults = {
+    url: null,
+    width: null,
+    height: null,
+  };
+
+  if (!seoImage && !hero.hasHero) return null;
+
+  if(!seoImage) {
+    obj = typeof hero === 'string' ? Object.assign({}, defaults, {url: hero}) : Object.assign({}, defaults, hero);
+  }else {
+    obj = typeof seoImage === 'string' ? Object.assign({}, defaults, {url: seoImage}) : Object.assign({}, defaults, seoImage);
+  }
+
+  return obj;
+})


### PR DESCRIPTION
- register and move some functions as hexo's helper

  In order to improve the reuse of the function for getting the full URL and the function for getting the representative image information, transferred the functions existing in the pug file to the helper of hexo.

- improving JSON-LD

  - Fixed JSON-LD grammar errors due to missing commas.
  - The page showing the post list has been modified to display the list in JSON-LD as well.  
  - Each individual post has been enhanced to include a representative image in JSON-LD.

- Fixed a grammatical error when double quotes were included in the body of the JSON-LD data.